### PR TITLE
feat(memory): Implement Redis-based conversation memory

### DIFF
--- a/src/core/config.py
+++ b/src/core/config.py
@@ -14,7 +14,7 @@ class Settings(BaseSettings):
     # --- 모델 설정 ---
     EMBEDDING_MODEL: str = "text-embedding-3-small"
     EMBEDDING_DIMENSIONS: Optional[int] = 512 # text-embedding-3용 차원 (None이면 기본값)
-    LLM_MODEL: str = "gpt-4o-mini"
+    LLM_MODEL: str = "gpt-o4-nano"
 
     # --- 데이터 경로 ---
     FAQ_DATA_PATH: str = "data/final_result.pkl" # 원본 데이터 경로
@@ -45,7 +45,7 @@ class Settings(BaseSettings):
     GENERATOR_TEMPERATURE: float = 0.7 # 답변 생성 온도
 
     # --- Guard 설정 ---
-    GUARD_CLASSIFIER_MODEL: str = "gpt-4o-mini" 
+    GUARD_CLASSIFIER_MODEL: str = "gpt-o4-nano" 
 
     # --- Tiered Logic Thresholds ---
     HIGH_THRESHOLD: float = 0.7   # 높은 유사도 기준 (직접 답변 유도)
@@ -54,7 +54,8 @@ class Settings(BaseSettings):
 
     # --- Memory 설정 ---
     CONTEXT_TURNS: int = 3 # 프롬프트에 포함할 최근 대화 턴 수
-    REDIS_TTL_SECONDS: int = 48 * 60 * 60 # Redis TTL (48시간)
+    REDIS_TTL_SECONDS: int = 12 * 60 * 60 # Redis TTL (48시간)
+    REDIS_URL: str = "redis://localhost:6379/0" # Redis URL
 
     # --- 앱 정보 ---
     APP_TITLE: str = "SmartStore FAQ Chatbot API"

--- a/src/modules/memory.py
+++ b/src/modules/memory.py
@@ -1,0 +1,118 @@
+# src/modules/memory.py
+import logging
+import json
+import time
+from typing import List, Optional, Dict, Any
+from redis.asyncio import Redis as AsyncRedis # redis 라이브러리 사용 (asyncio 지원)
+
+from src.schemas.common import Message # Message 스키마 임포트 (role, content 필드 가정)
+from src.core.config import settings # TTL 설정 등 가져오기
+
+logger = logging.getLogger(__name__)
+
+class ConversationMemory:
+    """
+    Redis를 사용하여 대화 기록을 관리하는 클래스 (비동기).
+    각 대화는 Redis List에 JSON 문자열 형태로 저장됩니다.
+    """
+    def __init__(self, redis_client: AsyncRedis, prefix: str = "convo:", ttl_seconds: int = settings.REDIS_TTL_SECONDS):
+        """
+        ConversationMemory 초기화.
+        :param redis_client: 비동기 Redis 클라이언트 인스턴스.
+        :param prefix: Redis 키 접두사.
+        :param ttl_seconds: 대화 기록 유지 시간 (초).
+        """
+        self.redis: AsyncRedis = redis_client
+        self.prefix = prefix
+        self.ttl_seconds = ttl_seconds
+        logger.info(f"ConversationMemory initialized with prefix '{prefix}' and TTL {ttl_seconds}s.")
+
+    def _get_key(self, conversation_id: str) -> str:
+        """대화 ID에 해당하는 Redis 키 생성"""
+        return f"{self.prefix}{conversation_id}"
+
+    async def add_message(self, conversation_id: str, message: Message):
+        """
+        대화에 메시지를 추가하고 TTL을 갱신합니다.
+        메시지는 JSON 문자열로 직렬화되어 저장됩니다.
+        """
+        if not conversation_id or not message or not message.content:
+            logger.warning("Attempted to add an empty message or use empty conversation_id. Skipping.")
+            return
+
+        key = self._get_key(conversation_id)
+        try:
+            # 메시지 객체를 딕셔너리로 변환하고 타임스탬프 추가
+            message_dict = message.model_dump() 
+            message_dict['timestamp'] = time.time()
+
+            # 딕셔너리를 JSON 문자열로 직렬화
+            message_json = json.dumps(message_dict, ensure_ascii=False)
+
+            # Redis List의 오른쪽에 메시지 추가 (RPUSH)
+            await self.redis.rpush(key, message_json)
+
+            # TTL 갱신 (키가 존재할 때만 TTL 설정)
+            # 참고: RPUSH는 키가 없으면 새로 생성하므로, 항상 TTL 설정 가능
+            await self.redis.expire(key, self.ttl_seconds)
+
+            logger.debug(f"Added message to conversation '{conversation_id}'. Role: {message.role}, Content: {message.content[:30]}...")
+
+        except Exception as e:
+            logger.error(f"Error adding message to Redis for conversation '{conversation_id}': {e}")
+            # 필요시 예외 재발생 또는 특정 처리
+
+    async def get_history(self, conversation_id: str, k: int = settings.CONTEXT_TURNS) -> List[Message]:
+        """
+        최근 k개의 대화 기록을 시간 순서대로 가져옵니다.
+        오래된 메시지가 리스트 앞쪽에 위치합니다.
+        """
+        if not conversation_id or k <= 0:
+            return []
+
+        key = self._get_key(conversation_id)
+        history: List[Message] = []
+        try:
+            # Redis List의 끝에서부터 k개의 요소 가져오기 (LRANGE 사용, 인덱스 주의)
+            # LRANGE key start stop (stop 포함)
+            # 끝에서 k개를 가져오려면 start = -k, stop = -1
+            # 예: 끝에서 3개 -> LRANGE key -3 -1
+            messages_json = await self.redis.lrange(key, -k, -1)
+
+            if messages_json:
+                logger.debug(f"Retrieved {len(messages_json)} raw messages for conversation '{conversation_id}'.")
+                for msg_json in messages_json:
+                    try:
+                        # JSON 문자열을 딕셔너리로 역직렬화
+                        msg_dict = json.loads(msg_json)
+                        # 딕셔너리를 Message 객체로 변환 (타임스탬프 제외 가능)
+                        # Pydantic 모델 생성 시 extra='ignore' 설정 필요할 수 있음
+                        history.append(Message(role=msg_dict.get('role'), content=msg_dict.get('content')))
+                    except json.JSONDecodeError:
+                        logger.warning(f"Failed to decode message JSON from Redis: {msg_json}")
+                    except Exception as parse_e: # Pydantic 유효성 검사 오류 등
+                         logger.warning(f"Failed to parse message object: {parse_e} - Data: {msg_dict}")
+
+                logger.info(f"Returning {len(history)} parsed messages for conversation '{conversation_id}'.")
+            else:
+                 logger.info(f"No history found for conversation '{conversation_id}'.")
+
+
+        except Exception as e:
+            logger.error(f"Error getting history from Redis for conversation '{conversation_id}': {e}")
+            # 오류 발생 시 빈 리스트 반환
+
+        return history
+
+    async def clear_history(self, conversation_id: str):
+        """특정 대화 기록 삭제"""
+        key = self._get_key(conversation_id)
+        try:
+            await self.redis.delete(key)
+            logger.info(f"Cleared history for conversation '{conversation_id}'.")
+        except Exception as e:
+            logger.error(f"Error clearing history for conversation '{conversation_id}': {e}")
+
+    # --- 추가 가능 메서드 ---
+    # async def get_last_message(self, conversation_id: str) -> Optional[Message]: ...
+    # async def count_messages(self, conversation_id: str) -> int: ...

--- a/src/schemas/common.py
+++ b/src/schemas/common.py
@@ -1,0 +1,12 @@
+# src/chatbot_api/schemas/common.py
+from pydantic import BaseModel, Field
+from typing import Literal
+
+class Message(BaseModel):
+    role: Literal["user", "assistant"] 
+    content: str = Field(..., min_length=1) 
+
+
+    model_config = {
+        "extra": "ignore" 
+    }

--- a/src/services/chat_service.py
+++ b/src/services/chat_service.py
@@ -5,31 +5,30 @@ from src.modules.retriever import Retriever
 from src.modules.generator import ChatGenerator
 from src.modules.guard import Guard
 from src.modules.query_analyzer import QueryAnalyzer
-# from src.core.memory import ConversationMemory
-from src.core.config import settings
-
+from src.modules.memory import ConversationMemory
+from src.core.config import settings        
+from src.schemas.common import Message
 logger = logging.getLogger(__name__)
 
 # 처리 경로 타입을 명시적으로 정의 (Literal 사용)
 ChatFlowType = Literal["OFF_TOPIC", "GENERATE_DIRECT", "GENERATE_STANDARD", "HANDLE_ERROR"]
 
 class ChatService:
-    def __init__(self, retriever: Retriever, generator: ChatGenerator, guard: Guard, query_analyzer: QueryAnalyzer):
+    def __init__(self, retriever: Retriever, generator: ChatGenerator, guard: Guard, query_analyzer: QueryAnalyzer, memory: ConversationMemory):
         self.retriever = retriever
         self.generator = generator
         self.guard = guard
         self.query_analyzer = query_analyzer
-        # self.memory = memory
+        self.memory = memory
         logger.info("ChatService initialized.")
 
     async def _load_history(self, conversation_id: str) -> List[Dict[str, str]]:
         """대화 기록 로드 및 포맷팅"""
         logger.debug(f"[{conversation_id}] Loading conversation history...")
-        # history_messages = await self.memory.get_history(conversation_id, k=settings.CONTEXT_TURNS)
-        # return [msg.model_dump() for msg in history_messages]
-        return []
-
-    async def _generate_response_tokens( # 이름 변경: 스트리밍 책임 명확화
+        history_messages = await self.memory.get_history(conversation_id, k=settings.CONTEXT_TURNS)
+        return [msg.model_dump() for msg in history_messages]
+         
+    async def _generate_response_tokens( 
         self,
         conversation_id: str,
         flow_type: ChatFlowType,
@@ -41,8 +40,40 @@ class ChatService:
         logger.debug(f"[{conversation_id}] Generating response tokens for flow type: {flow_type}")
 
         if flow_type == "OFF_TOPIC":
-            async for token in self.generator.stream_off_topic_response(user_query):
-                yield token
+            # 대화 기록이 없으면 오프 탑립 응답 스트리밍
+            if not history:
+                async for token in self.generator.stream_off_topic_response(user_query):
+                    yield token
+            else:
+                # 대화 기록이 있으면 오프 탑립 응답 스트리밍
+                prompt_type = "HISTORY_ANSWER_DIRECT"
+                main_answer_tokens = [] # 메인 답변 토큰 임시 저장
+
+                # 1. 메인 답변 스트리밍 및 토큰 수집
+                async for token, _ in self.generator.stream_main_answer( # 누적 답변은 사용 안 함
+                    user_query=user_query,
+                    history=history,
+                    retrieved_contexts=retrieved_contexts,
+                    prompt_type=prompt_type
+                ):
+                    main_answer_tokens.append(token)
+                    yield token # 토큰 즉시 전달
+
+                # 2. 후속 질문 생성 (메인 답변 완료 후)
+                if main_answer_tokens:
+                    main_answer_full = "".join(main_answer_tokens)
+                    follow_ups = await self.generator.generate_follow_up_questions(
+                        user_query=user_query,
+                        retrieved_contexts=retrieved_contexts,
+                        main_answer=main_answer_full
+                    )
+                    if follow_ups:
+                        follow_up_header = "\n\n--- 다음 질문 제안 ---\n"
+                        yield follow_up_header
+                        for fu in follow_ups:
+                            follow_up_line = f"- {fu}\n"
+                            yield follow_up_line
+
         elif flow_type in ["GENERATE_DIRECT", "GENERATE_STANDARD"]:
             prompt_type = "MAIN_ANSWER_DIRECT" if flow_type == "GENERATE_DIRECT" else "MAIN_ANSWER_STANDARD"
             main_answer_tokens = [] # 메인 답변 토큰 임시 저장
@@ -77,7 +108,7 @@ class ChatService:
 
     async def save_message(self, conversation_id: str, role: str, content: str):
          """메시지 저장 메서드 분리"""
-        #  await self.memory.add_message(conversation_id, Message(role=role, content=content))
+         await self.memory.add_message(conversation_id, Message(role=role, content=content))
 
     # --- Public Method ---
     async def process_chat_stream(

--- a/src/services/data_ingestion_service.py
+++ b/src/services/data_ingestion_service.py
@@ -29,7 +29,7 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_TOKENIZER_MODEL = "gpt-4o-mini"
+DEFAULT_TOKENIZER_MODEL = "cl100k_base"
 DEFAULT_CHUNK_SIZE = 350
 DEFAULT_CHUNK_OVERLAP = 50
 INGESTION_BATCH_SIZE = 64


### PR DESCRIPTION


### Description

사용자와 챗봇 간의 대화 기록을 저장하고 조회하는 `ConversationMemory` 모듈을 구현합니다. 이를 통해 챗봇이 이전 대화의 맥락을 이해하고 일관성 있는 답변을 제공할 수 있게 됩니다. 백엔드 저장소로는 Redis를 사용합니다.


*   **`ConversationMemory` 클래스 추가 (`src/modules/memory.py`):**
    *   비동기 Redis 클라이언트(`redis-py` async)를 사용하여 구현되었습니다.
    *   `add_message`: 사용자 또는 어시스턴트 메시지를 대화 ID별 Redis List에 JSON 형태로 저장 (`RPUSH`)하고 TTL을 갱신합니다.
    *   `get_history`: 특정 대화 ID에 대해 최근 K개의 메시지를 조회 (`LRANGE -k -1`)하여 `Message` 객체 리스트로 반환합니다.
    *   `clear_history`: 특정 대화 기록을 삭제합니다.
*   **`Message` 스키마 업데이트 (`src/schemas/common.py`):**
    *   `role`과 `content` 필드를 포함하는 Pydantic 모델을 정의/확인했습니다.
*   **설정 추가 (`core/config.py`):**
    *   `REDIS_URL`, `CONTEXT_TURNS`, `REDIS_TTL_SECONDS` 설정을 추가/확인했습니다.
*   **의존성 주입 설정 (`dependencies/common.py`):**
    *   `get_redis_client` 및 `get_memory` 함수를 추가/수정하여 `ConversationMemory` 인스턴스를 주입할 수 있도록 했습니다.
*   **`ChatService` 연동 (`services/chat_service.py`):**
    *   `_load_history` 메서드에서 `memory.get_history`를 호출하여 대화 기록을 가져옵니다.
    *   `save_message` 메서드를 추가하여 대화 종료 후 사용자 및 어시스턴트 메시지를 `memory.add_message`를 통해 저장합니다. (API 레이어에서 호출)
*   **라이브러리 추가:** `redis` 라이브러리 의존성을 추가했습니다 (`requirements.txt` 업데이트 필요).

